### PR TITLE
Compatibility for ndarray batches of images

### DIFF
--- a/models/mtcnn.py
+++ b/models/mtcnn.py
@@ -248,7 +248,7 @@ class MTCNN(nn.Module):
 
         # Determine if a batch or single image was passed
         batch_mode = True
-        if not isinstance(img, (list, tuple)):
+        if not isinstance(img, (list, tuple)) and not (isinstance(img, np.ndarray) and len(img.shape) == 4):
             img = [img]
             batch_boxes = [batch_boxes]
             batch_probs = [batch_probs]
@@ -373,7 +373,7 @@ class MTCNN(nn.Module):
         probs = np.array(probs)
         points = np.array(points)
 
-        if not isinstance(img, (list, tuple)):
+        if not isinstance(img, (list, tuple)) and not (isinstance(img, np.ndarray) and len(img.shape) == 4):
             boxes = boxes[0]
             probs = probs[0]
             points = points[0]


### PR DESCRIPTION
It was not possible to pass the mtcnn forward method a batch of np ndarrays images (4D images) stacked on the first dimension, even if described as possible in the documentation and working with the detection methods already implemented. I propose a little change to make it possible.
I have tested it against a batch of np ndarray images, a list of ndarrays images, a list of PIL images, single PIL and np ndarrays images and it is working.
Great package, thank you!