### PR TITLE
use fixed batch size for rnet and onet inference to avoid GPU out of …

### DIFF
--- a/models/utils/detect_face.py
+++ b/models/utils/detect_face.py
@@ -38,7 +38,7 @@ def fixed_batch_processing(im_data, model, model_name):
         out = model(batch)
         if is_onet:
             b.append(out[0])
-            c.append(out[1]
+            c.append(out[1])
             a.append(out[2])
         else:
             b.append(out[0])

--- a/models/utils/detect_face.py
+++ b/models/utils/detect_face.py
@@ -19,7 +19,7 @@ def fixed_batch_processing(im_data, model, model_name):
     im_data:   input for 'rnet' or 'onet'
     model : rnet or onet
     model_name : 'rnet' or 'onet'
-    ""
+    """
     assert (model_name in ['rnet', 'onet'])
 
     batch_size = 512

--- a/models/utils/detect_face.py
+++ b/models/utils/detect_face.py
@@ -28,7 +28,7 @@ def fixed_batch_processing(im_data, model, model_name):
     b = []
     a = []
     is_onet = (model_name == 'onet')
-    if is_onet
+    if is_onet:
         c = []
 
     for i in range(n_iter):


### PR DESCRIPTION
Hi Tim,
     Thank for your great work.  I tested facenet and observed GPU out of memory issue . Errors are something like:
"
 File "../python3.6/site-packages/facenet_pytorch/models/mtcnn.py", line 247, in forward
    batch_boxes, batch_probs = self.detect(img)
  File "../python3.6/site-packages/facenet_pytorch/models/mtcnn.py", line 350, in detect
    self.device
  File ".../python3.6/site-packages/facenet_pytorch/models/utils/detect_face.py", line 94, in detect_face
    out = rnet(im_data)
  File "../python3.6/site-packages/torch/nn/modules/module.py", line 722, in _call_impl
    result = self.forward(*input, **kwargs)
  File "../python3.6/site-packages/facenet_pytorch/models/mtcnn.py", line 84, in forward
    x = self.prelu1(x)
  File "..lib/python3.6/site-packages/torch/nn/modules/module.py", line 722, in _call_impl
    result = self.forward(*input, **kwargs)
  File "../python3.6/site-packages/torch/nn/modules/activation.py", line 988, in forward
    return F.prelu(input, self.weight)
  File "../python3.6/site-packages/torch/nn/functional.py", line 1319, in prelu
    return torch.prelu(input, weight)
RuntimeError: CUDA out of memory. Tried to allocate 2.66 GiB (GPU 0; 7.43 GiB total capacity; 3.17 GiB already allocated; 2.33 GiB free; 4.56 GiB reserved in total by PyTorch)
""

The root cause is that the batch size for 'rnet' and 'onet' is dynamic. Sometimes the batch size for rnet is very large ( greater than 20,000. This will lead to GPU out of memory issue.  In this pull request, I used fixed batch size (512).  I tested it on 48 hours video data (720p, detect all faces). With the fix,  I did not observe GPU out of memory error. Also GPU usage was much lower (reduced from > 7G to 3 G). 

Thanks

Jianxiong