### PR TITLE
Mtcnn box selection and extraction

### DIFF
--- a/models/mtcnn.py
+++ b/models/mtcnn.py
@@ -369,11 +369,27 @@ class MTCNN(nn.Module):
         Returns:
                 tuple(numpy.ndarray, numpy.ndarray, numpy.ndarray) -- Ix4 ndarray of bounding boxes for I images. Ix0 array of probabilities for each box, array of landmark points
         """
+
+        #copying batch detection from extract, but would be easier to ensure detect creates consistent output.
+        batch_mode = True
+        if (
+                not isinstance(imgs, (list, tuple)) and
+                not (isinstance(imgs, np.ndarray) and len(imgs.shape) == 4) and
+                not (isinstance(imgs, torch.Tensor) and len(imgs.shape) == 4)
+        ):
+            imgs = [imgs]
+            all_boxes = [all_boxes]
+            all_probs = [all_probs]
+            all_points = [all_points]
+            batch_mode = False
+
         selected_boxes, selected_probs, selected_points = [], [], []
         for boxes, points, probs, img in zip(all_boxes, all_points, all_probs, imgs):
+
             boxes = np.array(boxes)
             probs = np.array(probs)
             points = np.array(points)
+
             if len(boxes) == 0:
                 selected_boxes.append(None)
                 selected_probs.append([None])
@@ -407,9 +423,14 @@ class MTCNN(nn.Module):
             selected_probs.append(prob)
             selected_points.append(point)
 
-        selected_boxes = np.array(selected_boxes)
-        selected_probs = np.array(selected_probs)
-        selected_points = np.array(selected_points)
+        if batch_mode:
+            selected_boxes = np.array(selected_boxes)
+            selected_probs = np.array(selected_probs)
+            selected_points = np.array(selected_points)
+        else:
+            selected_boxes = selected_boxes[0]
+            selected_probs = selected_probs[0][0]
+            selected_points = selected_points[0]
 
         return selected_boxes, selected_probs, selected_points
 

--- a/models/mtcnn.py
+++ b/models/mtcnn.py
@@ -220,7 +220,6 @@ class MTCNN(nn.Module):
         if not self.selection_method:
             self.selection_method = 'largest' if self.select_largest else 'probability'
 
-
     def forward(self, img, save_path=None, return_prob=False):
         """Run MTCNN face detection on a PIL image or numpy array. This method performs both
         detection and extraction of faces, returning tensors representing detected faces rather


### PR DESCRIPTION
Addresses issue #120 

Also makes it easier to create workflows that extract intermediate MTCNN outputs (bounding boxes, points, probabilities).

Previously, using `MTCNN.detect` would have to be followed by replication of the code in `MTCNN.forward` to wrap `utils.extract_face` This puts the wrapper into its own method `MTCNN.extract`.

To address #120 a new method `MTCNN.select_boxes` has been added. Using the method 'center_weighted_size' yields better crops for most images where `keep_all` is `False`. Results show ~3% boost in accuracy on LFW.

The first commit simply adds these new methods, extending `MTCNN` without any refactor. The next commit removes the code in `forward` that is now present in `extract` and replaces with calls to `detect`,`select_boxes`,`extract`. I believe these changes to be backwards compatible with existing workflows using `forward`. I saw no changes in output when testing.

There is still some redundancy between `detect` and `select_boxes`, but I didn't see an easy way to solve this without breaking existing workflows using `detect` directly.

Demonstration notebook here: https://github.com/zack-kimble/cv_sandbox/blob/master/facenet/facenet_pytorch_test_mtcnn_forward.ipynb