### PR TITLE
numpy throwing deprecation warning for creating ndarray from nested sequences (#196)

### DIFF
--- a/models/mtcnn.py
+++ b/models/mtcnn.py
@@ -336,9 +336,9 @@ class MTCNN(nn.Module):
                 boxes.append(box[:, :4])
                 probs.append(box[:, 4])
                 points.append(point)
-        boxes = np.array(boxes)
-        probs = np.array(probs)
-        points = np.array(points)
+        boxes = np.array(boxes, dtype=object)
+        probs = np.array(probs, dtype=object)
+        points = np.array(points, dtype=object)
 
         if (
             not isinstance(img, (list, tuple)) and 

--- a/models/utils/detect_face.py
+++ b/models/utils/detect_face.py
@@ -180,7 +180,7 @@ def detect_face(imgs, minsize, pnet, rnet, onet, threshold, factor, device):
         batch_boxes.append(boxes[b_i_inds].copy())
         batch_points.append(points[b_i_inds].copy())
 
-    batch_boxes, batch_points = np.array(batch_boxes), np.array(batch_points)
+    batch_boxes, batch_points = np.array(batch_boxes, dtype=object), np.array(batch_points, dtype=object)
 
     return batch_boxes, batch_points
 


### PR DESCRIPTION
Numpy is throwing deprecation warnings for creating arrays from nested sequences on line 183 of detect_face.py and on lines 339, 340, 341 of mtcnn.py when running the example training script. The fix is to pass 'dtype=object' as a parameter when creating the ndarray. E.g., on line 339 of mtcnn.py np.array(boxes) becomes np.array(boxes, dtype=object)