### PR TITLE
Remove cast to float32, that breaks face output

### DIFF
--- a/models/utils/detect_face.py
+++ b/models/utils/detect_face.py
@@ -373,6 +373,4 @@ def extract_face(img, box, image_size=160, margin=0, save_path=None):
         os.makedirs(os.path.dirname(save_path) + "/", exist_ok=True)
         save_img(face, save_path)
 
-    face = F.to_tensor(np.float32(face))
-
     return face


### PR DESCRIPTION
To reproduce - try saving the tensor returned from the forward pass as a `PIL.Image` using `torchvision.transforms.ToPILImage`. This image will be distorted due to the dtype conversion.