### PR TITLE
detect_face bug-fix for list of torch tensors

### DIFF
--- a/models/utils/detect_face.py
+++ b/models/utils/detect_face.py
@@ -35,7 +35,7 @@ def detect_face(imgs, minsize, pnet, rnet, onet, threshold, factor, device):
     else:
         if not isinstance(imgs, (list, tuple)):
             imgs = [imgs]
-        if any(img.size != imgs[0].size for img in imgs):
+        if any(img.size() != imgs[0].size() for img in imgs):
             raise Exception("MTCNN batch processing only compatible with equal-dimension images.")
         imgs = np.stack([np.uint8(img) for img in imgs])
         imgs = torch.as_tensor(imgs.copy(), device=device)


### PR DESCRIPTION
bug-fix` .size `instead of `size()`.
`size` is the method. `size()` is the correct equivalent to `shape`
